### PR TITLE
Move osx_image into the individual jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,17 +17,18 @@ language: python
 python: 3.5
 dist: xenial
 services: docker
-osx_image: xcode9.3
 
 jobs:
   include:
     - name: "3.5 macOS"
       os: osx
+      osx_image: xcode9.3
       language: generic
       env:
         - MB_PYTHON_VERSION=3.5
     - name: "3.6 macOS"
       os: osx
+      osx_image: xcode9.3
       language: generic
       env:
         - MB_PYTHON_VERSION=3.6
@@ -53,11 +54,13 @@ jobs:
 
     - name: "3.7 macOS"
       os: osx
+      osx_image: xcode9.3
       language: generic
       env:
         - MB_PYTHON_VERSION=3.7
     - name: "3.8 macOS"
       os: osx
+      osx_image: xcode9.3
       language: generic
       env:
         - MB_PYTHON_VERSION=3.8
@@ -83,12 +86,14 @@ jobs:
 
     - name: "3.5 macOS latest"
       os: osx
+      osx_image: xcode9.3
       language: generic
       env:
         - MB_PYTHON_VERSION=3.5
         - LATEST="true"
     - name: "3.6 macOS latest"
       os: osx
+      osx_image: xcode9.3
       language: generic
       env:
         - MB_PYTHON_VERSION=3.6
@@ -119,12 +124,14 @@ jobs:
 
     - name: "3.7 macOS latest"
       os: osx
+      osx_image: xcode9.3
       language: generic
       env:
         - MB_PYTHON_VERSION=3.7
         - LATEST="true"
     - name: "3.8 macOS latest"
       os: osx
+      osx_image: xcode9.3
       language: generic
       env:
         - MB_PYTHON_VERSION=3.8


### PR DESCRIPTION
Investigating https://github.com/python-pillow/pillow-wheels/pull/142, I found that [Travis was running Xcode 9.4](https://travis-ci.org/github/python-pillow/pillow-wheels/jobs/664125099#L28), despite the fact that we specify [Xcode 9.3](https://github.com/python-pillow/pillow-wheels/blob/0c6f7ffc207f10114b6d15f8f6880ea0c718b247/.travis.yml#L20).

Moving `osx_image` inside the individual jobs fixes this.