### PR TITLE
PyPy3.7 is no longer supported

### DIFF
--- a/.github/workflows/wheels-macos.yml
+++ b/.github/workflows/wheels-macos.yml
@@ -34,8 +34,6 @@ jobs:
         exclude:
           - python: "3.7"
             platform: "arm64"
-          - python: "pypy3.7-7.3.9"
-            platform: "arm64"
           - python: "pypy3.8-7.3.9"
             platform: "arm64"
           - python: "pypy3.9-7.3.9"


### PR DESCRIPTION
Suggestion for https://github.com/python-pillow/pillow-wheels/pull/349

Since PyPy3.7 is no longer listed in the matrix, it no longer needs to be excluded.