### PR TITLE
tkinter is disabled for macOS PyPy

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -144,7 +144,11 @@ function run_tests_in_repo {
 }
 
 EXP_CODECS="jpg jpg_2000 libtiff zlib"
-EXP_MODULES="freetype2 littlecms2 pil tkinter webp"
+if [[ "$MB_PYTHON_VERSION" == pypy3.* ]] && [ -n "$IS_MACOS" ]; then
+    EXP_MODULES="freetype2 littlecms2 pil webp"
+else
+    EXP_MODULES="freetype2 littlecms2 pil tkinter webp"
+fi
 EXP_FEATURES="fribidi harfbuzz libjpeg_turbo raqm transp_webp webp_anim webp_mux xcb"
 
 function run_tests {


### PR DESCRIPTION
In light of https://foss.heptapod.net/pypy/pypy/-/issues/3868#note_193028, this is for https://github.com/python-pillow/pillow-wheels/pull/349